### PR TITLE
feat: migration of the LMDB cache into separate contracts and sources…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prettier:format": "prettier --config .prettierrc 'src/**/*.js' --write",
-
     "prepublishOnly": "yarn-or-npm lint",
     "preversion": "yarn-or-npm lint && yarn-or-npm build",
-
     "generate-arweave-wallet": "node src/tools/generateArweaveWallet.js",
     "run-bullmq": "docker-compose up -d bullmq",
     "run-docker": "docker-compose up -d",
@@ -39,7 +37,7 @@
     "koa-compress": "^5.1.0",
     "node-nlp": "^4.24.0",
     "safe-stable-stringify": "^2.4.1",
-    "warp-contracts": "1.2.37",
+    "warp-contracts": "1.2.38",
     "warp-contracts-evaluation-progress-plugin": "1.0.17",
     "warp-contracts-lmdb": "1.1.5",
     "warp-contracts-nlp-plugin": "1.0.7",
@@ -48,6 +46,8 @@
     "websocket": "^1.0.34"
   },
   "devDependencies": {
+    "cli-progress": "^3.11.2",
+    "command-line-args": "^5.2.1",
     "deep-object-diff": "^1.1.9",
     "eslint": "^8.30.0",
     "eslint-config-prettier": "^8.5.0",

--- a/src/tools/migrateToDividedCache.ts
+++ b/src/tools/migrateToDividedCache.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+const { LmdbCache } = require('warp-contracts-lmdb');
+const { defaultCacheOptions, SrcCache, ContractCache, ContractDefinition } = require('warp-contracts');
+
+const commandLineArgs = require('command-line-args');
+const cliProgress = require('cli-progress');
+const optionDefinitions = [
+  { name: 'inContracts', type: String, alias: 'i' },
+  { name: 'outContracts', type: String, alias: 'c' },
+  { name: 'outSource', type: String, alias: 's' },
+];
+
+// Contract cache was divided in Warp into:
+// - contracts (path: /contracts) 
+// - sources (path: /source) 
+// in order to de-duplicate sources.
+// This script:
+// - goes through all contracts
+// - saves sources to dedicated cache
+// - saves contracts to dedicated cache
+async function main() {
+  const args = commandLineArgs(optionDefinitions);
+  if (args.inContracts === args.outContracts) {
+    console.error("Input and output contracts folders can't be the same");
+    return;
+  }
+
+  const inContracts = new LmdbCache({ ...defaultCacheOptions, dbLocation: args.inContracts }).storage();
+  const outContracts = new LmdbCache({ ...defaultCacheOptions, dbLocation: args.outContracts }).storage();
+  const outSource = new LmdbCache({ ...defaultCacheOptions, dbLocation: args.outSource }).storage();
+
+  const bar = new cliProgress.SingleBar(
+    {
+      etaBuffer: 1000
+    },
+    cliProgress.Presets.shades_classic
+  );
+  bar.start(inContracts.getKeysCount(), 0);
+
+  inContracts.transactionSync(() => {
+    inContracts.getRange().forEach(({ key, value }: any) => {
+      const v = value as typeof ContractDefinition
+      const k = key as string
+      let srcTxId: string = k
+      if (k.charAt(43) === "_") {
+        srcTxId = k.substring(44)
+      }
+      srcTxId = srcTxId.replace("|cd", "|src")
+
+      outContracts.putSync(key, new ContractCache(v))
+      outSource.putSync(srcTxId, new SrcCache(v))
+
+      bar.increment();
+    });
+  });
+
+  bar.stop();
+}
+
+main().catch((e) => console.error(e));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1811,6 +1811,11 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
 arweave@1.11.8:
   version "1.11.8"
   resolved "https://registry.npmjs.org/arweave/-/arweave-1.11.8.tgz"
@@ -2148,6 +2153,13 @@ classic-level@^1.2.0:
     napi-macros "~2.0.0"
     node-gyp-build "^4.3.0"
 
+cli-progress@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.11.2.tgz#f8c89bd157e74f3f2c43bcfb3505670b4d48fc77"
+  integrity sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==
+  dependencies:
+    string-width "^4.2.3"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz"
@@ -2205,6 +2217,16 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+command-line-args@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.1.tgz#c44c32e437a57d7c51157696893c5909e9cec42e"
+  integrity sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
 
 commander@^9.1.0:
   version "9.4.1"
@@ -2752,6 +2774,13 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
 
 find-up@5.0.0, find-up@^5.0.0:
   version "5.0.0"
@@ -3480,6 +3509,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
 lodash.defaults@^4.2.0:
   version "4.2.0"
@@ -4376,7 +4410,7 @@ streamsearch@^1.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4561,6 +4595,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
 undici@^4.12.2:
   version "4.16.0"
   resolved "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz"
@@ -4701,10 +4740,10 @@ warp-contracts-pubsub@^1.0.4:
     isomorphic-ws "^5.0.0"
     ws "^8.11.0"
 
-warp-contracts@1.2.37:
-  version "1.2.37"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.2.37.tgz#dec8164200a5bfeb2f176e527f9f3cc7e6a73d26"
-  integrity sha512-WP9uGClr7Dl7djzKJ8ui0cAcQzbkTh1yuXd+aonz+WBbi3xVBnwH/iJf0hPIgmi6wWbCU+NnjCrXVJ+rbIk9Kg==
+warp-contracts@1.2.38:
+  version "1.2.38"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.2.38.tgz#2f6833dbc94e6bc70472d091bf50ef12aeeeb493"
+  integrity sha512-E5ns8CI5sTKkurA8FZTMdQZlEks3SUDlc9o+4Nw+5zcxcwQZNMwsoxHddynYi8OlMDQy6xDCi4ooSTwQAwuvrg==
   dependencies:
     "@assemblyscript/loader" "^0.19.23"
     "@idena/vrf-js" "^1.0.1"


### PR DESCRIPTION
Described in: warp-contracts/warp#261

**This PR doesn't property initialize two caches in DRE**, it only does the migration.  

```
ts-node src/tools/migrateToDividedCache.ts -i ../tmp/cache/warp/lmdb/contract -c ../tmp/big/contract -s ../tmp/big/source
```