### PR TITLE
Persistent volumes for helm chart

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -11,6 +11,8 @@ NODE_JWK_KEY=''
 PUBSUB_TYPE=redis
 # required only if PUBSUB_TYPE=streamr
 STREAMR_STREAM_ID=''
+STREAMR_STREAM_HOST=''
+STREAMR_STREAM_PORT=''
 
 ## Warp GW Redis connection, required only if PUBSUB_TYPE=redis
 # required only if the PUBSUB_TYPE=redis #

--- a/.env.defaults
+++ b/.env.defaults
@@ -16,9 +16,9 @@ STREAMR_STREAM_PORT=''
 
 ## Warp GW Redis connection, required only if PUBSUB_TYPE=redis
 # required only if the PUBSUB_TYPE=redis #
-GW_PORT=''
-GW_HOST=''
-GW_USERNAME=default
+GW_PORT=6379
+GW_HOST=dre-redis-read.warp.cc
+GW_USERNAME=contracts
 GW_PASSWORD=''
 GW_TLS=true
 GW_ENABLE_OFFLINE_QUEUE=true

--- a/helm/templates/stateful-set.yaml
+++ b/helm/templates/stateful-set.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "warp-dre-node.fullname" . }}
   labels:
     {{- include "warp-dre-node.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "warp-dre-node.fullname" . }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -33,6 +34,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: sqlite-volume
+              mountPath: /app/sqlite
+            - name: cache-volume
+              mountPath: /app/cache
           env:
             - name: BULLMQ_HOST
               value: localhost
@@ -53,6 +59,7 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
         - name: redis
           image: redis:7.0-alpine
 {{/*          ports:*/}}
@@ -73,3 +80,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: sqlite-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: cache-volume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: warpredstone/dre
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: pr-4
+  tag: main
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: warpredstone/dre

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,9 +6,9 @@ replicaCount: 2
 
 image:
   repository: warpredstone/dre
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: main
+  tag: dev
 
 imagePullSecrets: []
 nameOverride: ""

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "warp-contracts": "1.2.37",
     "warp-contracts-evaluation-progress-plugin": "1.0.17",
     "warp-contracts-lmdb": "1.1.5",
-    "warp-contracts-plugin-nlp": "1.0.8",
     "warp-contracts-plugin-ethers": "1.0.7",
+    "warp-contracts-plugin-nlp": "1.0.8",
     "warp-contracts-plugin-signature": "1.0.8",
-    "warp-contracts-pubsub": "^1.0.4",
+    "warp-contracts-pubsub": "^1.0.5",
     "websocket": "^1.0.34"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "run-docker": "docker-compose up -d",
     "stop-docker": "docker-compose down",
     "start": "yarn-or-npm run run-bullmq && node src/listener.js",
-    "start:prod": "ENV=prod yarn-or-npm run run-bullmq && node src/listener.js",
-    "start:test": "ENV=test yarn-or-npm run run-bullmq && node src/listener.js"
+    "start:prod": "yarn-or-npm run run-bullmq && ENV=prod node src/listener.js",
+    "start:test": "yarn-or-npm run run-bullmq && ENV=test node src/listener.js"
   },
   "engines": {
     "node": ">=16.5"

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,11 @@ const evaluationOptions = {
 
 const config = {
   env: process.env.ENV,
-  streamId: process.env.STREAMR_STREAM_ID,
+  streamr: {
+    id: process.env.STREAMR_STREAM_ID,
+    host: process.env.STREAMR_STREAM_HOST,
+    port: process.env.STREAMR_STREAM_PORT,
+  },
   arweave,
   gwPubSubConfig: {
     port: process.env.GW_PORT ? parseInt(process.env.GW_PORT) : process.env.GW_PORT,
@@ -134,6 +138,7 @@ async function logConfig(config) {
   logger.info('---------');
   logger.info('evaluationOptions', config.evaluationOptions);
   logger.info('workersConfig', config.workersConfig);
+  logger.info('streamr', config.streamr);
 }
 
 module.exports.config = config;

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ const config = {
   streamr: {
     id: process.env.STREAMR_STREAM_ID,
     host: process.env.STREAMR_STREAM_HOST,
-    port: process.env.STREAMR_STREAM_PORT,
+    port: parseInt(process.env.STREAMR_STREAM_PORT),
   },
   arweave,
   gwPubSubConfig: {

--- a/src/listener.js
+++ b/src/listener.js
@@ -269,12 +269,22 @@ async function subscribeToGatewayNotifications(nodeDb, nodeDbEvents, updatedQueu
   logger.info(`Starting pubsub in ${pubsubType} mode`);
   switch (pubsubType) {
     case 'streamr': {
-      const pubsub = new StreamrWsClient({
+      const connection = {
         direction: 'sub',
-        streamId: config.streamId
-      });
+        streamId: config.streamr.id
+      };
+      if (config.streamr.host) {
+        connection.readHost = config.streamr.host;
+      }
+      if (config.streamr.port) {
+        connection.readPort = config.streamr.port;
+      }
+      const pubsub = new StreamrWsClient(connection);
       pubsub.sub(onMessage, onError);
-      process.on('exit', () => pubsub.close());
+      process.on('exit', () => {
+        logger.info('Closing pubsub');
+        pubsub.close();
+      });
       break;
     }
     case 'redis': {

--- a/src/listener.js
+++ b/src/listener.js
@@ -279,7 +279,7 @@ async function subscribeToGatewayNotifications(nodeDb, nodeDbEvents, updatedQueu
       if (config.streamr.port) {
         connection.readPort = config.streamr.port;
       }
-      const pubsub = new StreamrWsClient(connection);
+      const pubsub = await StreamrWsClient.create(connection);
       pubsub.sub(onMessage, onError);
       process.on('exit', () => {
         logger.info('Closing pubsub');

--- a/src/tools/cacheSafeContractsStreamr.js
+++ b/src/tools/cacheSafeContractsStreamr.js
@@ -12,7 +12,7 @@ const WebSocketClient = require('websocket').client;
     console.log('Connect Error: ' + error.toString());
   });
   client.on('connect', async (connection) => {
-    contracts = contracts.slice(0, 2);
+    contracts = contracts.slice(0, 1);
     console.log('WebSocket Client Connected');
     connection.on('error', function (error) {
       console.log('Connection Error: ' + error.toString());
@@ -23,7 +23,7 @@ const WebSocketClient = require('websocket').client;
 
     for (let contract of contracts) {
       console.log('Publishing', contract);
-      const message = { contractTxId: contract.contract_id, test: true, interaction: {} };
+      const message = { contractTxId: contract.contract_id, test: false, interaction: {} };
       // publisher.publish(channel, JSON.stringify(message));
       connection.sendUTF(JSON.stringify(message));
 
@@ -35,7 +35,9 @@ const WebSocketClient = require('websocket').client;
 
   let streamId = '0xc2ae2d5523080b64cc788cddc91ff59a3e29f911/common';
   let port = 7180;
-  let url = `ws://redstone-nlb-prod-b3c531f79942790e.elb.eu-central-1.amazonaws.com`;
+  let url = `ws://write.streamr.warp.cc`;
+  // let url = `ws://34.107.60.243`;
+  // let url = `ws://redstone-nlb-prod-b3c531f79942790e.elb.eu-central-1.amazonaws.com`;
   let requestUrl = `${url}:${port}/streams/${encodeURIComponent(
     streamId
   )}/publish?apiKey=YjZhODI3MzRiMzA3NDlkNGIxYjVmYjllMmE4MzViZWI`;

--- a/src/tools/cacheSafeContractsStreamr.js
+++ b/src/tools/cacheSafeContractsStreamr.js
@@ -36,7 +36,6 @@ const WebSocketClient = require('websocket').client;
   let streamId = '0xc2ae2d5523080b64cc788cddc91ff59a3e29f911/common';
   let port = 7180;
   let url = `ws://write.streamr.warp.cc`;
-  // let url = `ws://34.107.60.243`;
   // let url = `ws://redstone-nlb-prod-b3c531f79942790e.elb.eu-central-1.amazonaws.com`;
   let requestUrl = `${url}:${port}/streams/${encodeURIComponent(
     streamId

--- a/yarn.lock
+++ b/yarn.lock
@@ -4855,10 +4855,10 @@ warp-contracts-plugin-signature@1.0.8:
     ethers "^5.7.2"
     safe-stable-stringify "^2.4.1"
 
-warp-contracts-pubsub@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/warp-contracts-pubsub/-/warp-contracts-pubsub-1.0.4.tgz#629a66e4a87b2070cbc941a2c6c092fa1861ea1b"
-  integrity sha512-XfS8gvzKYq6ert+JjmvG9RhciT/hJi4NUFc1QPC865GWdJHHBrb6usYaECgzOlNrzw5NMOSYYz4+Yyb3IQh5Xw==
+warp-contracts-pubsub@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/warp-contracts-pubsub/-/warp-contracts-pubsub-1.0.5.tgz#6193749997874a3ccd1f9a2c8a921bcfa0252eb2"
+  integrity sha512-8p6qv7i2qgsMit8ldMHNEX09Lqip3/Sw48kRixGWPduGPrXyVkCZxGqcH51Oz4/vzyNYe7650lKlgM9MruGI+Q==
   dependencies:
     "@aws-amplify/api" "^4.0.61"
     "@aws-amplify/core" "4.7.12"


### PR DESCRIPTION
DRE node requires to have a state between runs. In kubernetes, we should use persistence volumes for it and use [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) instead of [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/).