### PR TITLE
Use docker image in the docker-compose.yml

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,13 +1,13 @@
 version: '3.8'
 services:
   dre:
-    image: "warpredstone/dre:${DRE_IMAGE_TAG:-latest}"
+    build: .
     env_file:
       - .env
     environment:
       BULLMQ_HOST: "${BULLMQ_HOST:-bullmq}"
     ports:
-      - '80:8080'
+      - '8080:8080'
 
     volumes:
       - dre-sqlite:/app/sqlite


### PR DESCRIPTION
Use an image from the docker hub in docker-compose instead of build.
Option with build moved in the docker-compose-local.yml for local development.